### PR TITLE
Apply Zuplo design system

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>uuid.new</title>
+    <meta
+      name="description"
+      content="Generate a fresh UUID instantly. Free API powered by Zuplo."
+    />
+    <title>uuid.new — Instant UUID generator</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "uuid.new",
       "version": "0.0.0",
       "dependencies": {
+        "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-select": "^2.2.2",
         "@radix-ui/react-slot": "^1.1.2",
         "@tailwindcss/vite": "^4.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.506.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-syntax-highlighter": "^15.6.1",
@@ -737,6 +737,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3500,15 +3513,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.506.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.506.0.tgz",
-      "integrity": "sha512-/2znFFzlXcZKu0ANFCnxUOBV5I2e08m19PGtb6X+BcByRj8ODlGAl3wpe4LNVrDMLJ263JoIkZn7MOGK/5sXtw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@tailwindcss/vite": "^4.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.506.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-syntax-highlighter": "^15.6.1",

--- a/src/App.css
+++ b/src/App.css
@@ -5,61 +5,54 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: 215 28% 17%;
-  --foreground: 0 0% 100%;
-  --primary: 324 100% 50%;
+  /* Brand accent */
+  --accent: #ff00bd;
+  --accent-hover: #e600aa;
+  --accent-light: #fff0fb;
+  --accent-ghost: rgba(255, 0, 189, 0.08);
+  --accent-muted: rgba(255, 0, 189, 0.3);
 
-  --card: hsl(0 0% 100%);
-  --card-foreground: hsl(0 0% 3.9%);
-  --popover: hsl(0 0% 100%);
-  --popover-foreground: hsl(0 0% 3.9%);
-  --primary: hsl(0 0% 9%);
-  --primary-foreground: hsl(0 0% 98%);
-  --secondary: hsl(0 0% 96.1%);
-  --secondary-foreground: hsl(0 0% 9%);
-  --muted: hsl(0 0% 96.1%);
-  --muted-foreground: hsl(0 0% 45.1%);
-  --accent: hsl(0 0% 96.1%);
-  --accent-foreground: hsl(0 0% 9%);
-  --destructive: hsl(0 84.2% 60.2%);
-  --destructive-foreground: hsl(0 0% 98%);
-  --border: hsl(0 0% 89.8%);
-  --input: hsl(0 0% 89.8%);
-  --ring: hsl(0 0% 3.9%);
-  --chart-1: hsl(12 76% 61%);
-  --chart-2: hsl(173 58% 39%);
-  --chart-3: hsl(197 37% 24%);
-  --chart-4: hsl(43 74% 66%);
-  --chart-5: hsl(27 87% 67%);
-  --radius: 0.6rem;
-}
+  /* Neutrals */
+  --foreground: #111827;
+  --foreground-secondary: #374151;
+  --foreground-muted: #6b7280;
+  --foreground-faint: #9ca3af;
+  --background: #ffffff;
+  --background-subtle: #f9fafb;
+  --background-muted: #f3f4f6;
+  --border: #e5e7eb;
+  --border-strong: #d1d5db;
 
-.dark {
-  --background: 215 28% 17%;
-  --foreground: 0 0% 100%;
-  --primary: 324 100% 50%;
-  --card: hsl(0 0% 3.9%);
-  --card-foreground: hsl(0 0% 98%);
-  --popover: hsl(0 0% 3.9%);
-  --popover-foreground: hsl(0 0% 98%);
-  --primary: hsl(0 0% 98%);
-  --primary-foreground: hsl(0 0% 9%);
-  --secondary: hsl(0 0% 14.9%);
-  --secondary-foreground: hsl(0 0% 98%);
-  --muted: hsl(0 0% 14.9%);
-  --muted-foreground: hsl(0 0% 63.9%);
-  --accent: hsl(0 0% 14.9%);
-  --accent-foreground: hsl(0 0% 98%);
-  --destructive: hsl(0 62.8% 30.6%);
-  --destructive-foreground: hsl(0 0% 98%);
-  --border: hsl(0 0% 14.9%);
-  --input: hsl(0 0% 14.9%);
-  --ring: hsl(0 0% 83.1%);
-  --chart-1: hsl(220 70% 50%);
-  --chart-2: hsl(160 60% 45%);
-  --chart-3: hsl(30 80% 55%);
-  --chart-4: hsl(280 65% 60%);
-  --chart-5: hsl(340 75% 55%);
+  /* Semantic */
+  --success: #10b981;
+  --success-bg: #ecfdf5;
+  --error: #e11d48;
+  --error-bg: #ffe4e6;
+  --warning: #f59e0b;
+  --warning-bg: #fffbeb;
+  --info: #6366f1;
+  --info-bg: #e0e7ff;
+
+  /* Code surface */
+  --code-bg: #1e1e2e;
+  --code-fg: #cdd6f4;
+
+  /* shadcn bindings (kept for compat) */
+  --card: var(--background);
+  --card-foreground: var(--foreground);
+  --popover: var(--background);
+  --popover-foreground: var(--foreground);
+  --primary: var(--accent);
+  --primary-foreground: #ffffff;
+  --secondary: var(--background-muted);
+  --secondary-foreground: var(--foreground);
+  --muted: var(--background-muted);
+  --muted-foreground: var(--foreground-muted);
+  --destructive: var(--error);
+  --destructive-foreground: #ffffff;
+  --input: var(--border);
+  --ring: var(--accent);
+  --radius: 0.5rem;
 }
 
 @theme inline {
@@ -76,17 +69,12 @@
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
+  --color-accent-foreground: #ffffff;
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -218,7 +218,7 @@ Content-Type: application/json`,
         <p className="text-[12px] text-[#6b7280] text-center mt-6">
           Powered by{" "}
           <a
-            href="https://zuplo.com"
+            href="https://zuplo.com?utm_source=uuid-new&utm_campaign=opensource&utm_medium=web"
             target="_blank"
             rel="noopener noreferrer"
             className="text-[#FF00BD] font-semibold hover:underline"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Check, Copy, Braces, Code } from "lucide-react";
+import { Check, Copy, BracketsCurly, Code, ArrowsClockwise } from "@phosphor-icons/react";
 import { useCallback, useMemo, useState } from "react";
 import {
   CustomSelect,
@@ -77,7 +77,6 @@ Content-Type: application/json`,
     http: "HTTP",
   };
 
-  // Map our language keys to Prism's language keys
   const prismLanguageMap = {
     curl: "bash",
     javascript: "javascript",
@@ -107,59 +106,72 @@ Content-Type: application/json`,
   }, [selectedLanguage, codeSnippets]);
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-white">
-      <div className="fixed top-0 left-0 right-0 z-50 bg-gray-900/50 backdrop-blur-sm">
-        <zuplo-banner mode="dark"></zuplo-banner>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-[#f9fafb] text-[#111827] px-4 py-16">
+      <div className="fixed top-0 left-0 right-0 z-50">
+        <zuplo-banner mode="light"></zuplo-banner>
       </div>
 
-      <div className="w-full max-w-md px-4">
+      <div className="w-full max-w-md">
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-bold">uuid.new</h1>
-          <Braces className="h-6 w-6 text-pink-500" />
+          <h1 className="text-[28px] font-semibold tracking-[-0.3px] leading-[1.2]">
+            uuid.new
+          </h1>
+          <BracketsCurly size={24} weight="regular" className="text-[#FF00BD]" />
         </div>
-        <div className="bg-gray-800 rounded-lg p-4 mb-4">
-          <div className="flex items-center justify-between">
-            <code className="font-mono text-sm text-gray-300">{uuid}</code>
+
+        <div className="bg-white border border-[#e5e7eb] rounded-xl p-5 mb-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)]">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-[#9ca3af] mb-2">
+            Your UUID
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <code className="font-mono text-[14px] text-[#111827] break-all">
+              {uuid}
+            </code>
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 text-gray-400 hover:text-pink-500"
+              className="shrink-0 h-9 w-9"
               onClick={copyUuid}
+              aria-label="Copy UUID"
             >
               {copied ? (
-                <Check className="h-4 w-4" />
+                <Check size={16} weight="regular" className="text-[#10b981]" />
               ) : (
-                <Copy className="h-4 w-4" />
+                <Copy size={16} weight="regular" />
               )}
-              <span className="sr-only">Copy UUID</span>
             </Button>
           </div>
         </div>
+
         <Button
           onClick={generateNewUuid}
-          className="w-full bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white mb-6"
+          className="w-full mb-8"
           size="lg"
         >
-          Generate New UUID
+          <ArrowsClockwise size={16} weight="regular" />
+          Generate new UUID
         </Button>
-        <div className="bg-gray-800 rounded-lg p-4">
-          <div className="flex items-center justify-between mb-3">
-            <div className="flex items-center">
-              <Code className="h-4 w-4 mr-2 text-pink-500" />
-              <span className="text-sm font-semibold">API Examples</span>
+
+        <div className="bg-white border border-[#e5e7eb] rounded-xl p-5 shadow-[0_1px_3px_rgba(0,0,0,0.04)]">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <Code size={16} weight="regular" className="text-[#6b7280]" />
+              <h2 className="text-[15px] font-semibold text-[#111827]">
+                API examples
+              </h2>
             </div>
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 text-gray-400 hover:text-pink-500"
+              className="h-9 w-9"
               onClick={copySnippet}
+              aria-label="Copy code snippet"
             >
               {snippetCopied ? (
-                <Check className="h-4 w-4" />
+                <Check size={16} weight="regular" className="text-[#10b981]" />
               ) : (
-                <Copy className="h-4 w-4" />
+                <Copy size={16} weight="regular" />
               )}
-              <span className="sr-only">Copy Code Snippet</span>
             </Button>
           </div>
 
@@ -170,7 +182,7 @@ Content-Type: application/json`,
                 setSelectedLanguage(value as keyof typeof prismLanguageMap)
               }
             >
-              <CustomSelectTrigger className="w-full bg-gray-700 border-gray-600">
+              <CustomSelectTrigger className="w-full">
                 <CustomSelectValue placeholder="Select language" />
               </CustomSelectTrigger>
               <CustomSelectContent>
@@ -183,22 +195,37 @@ Content-Type: application/json`,
             </CustomSelect>
           </div>
 
-          <div className="rounded overflow-hidden">
+          <div className="rounded-lg overflow-hidden border border-[#1e1e2e]">
             <SyntaxHighlighter
               language={prismLanguageMap[selectedLanguage]}
               style={vscDarkPlus}
               customStyle={{
                 margin: 0,
-                padding: "0.75rem",
-                borderRadius: "0.25rem",
-                fontSize: "0.875rem",
-                backgroundColor: "#1a1a1a",
+                padding: "14px 16px",
+                borderRadius: 0,
+                fontSize: "13px",
+                fontFamily:
+                  "'Fira Code', 'SF Mono', ui-monospace, monospace",
+                fontWeight: 400,
+                backgroundColor: "#1e1e2e",
               }}
             >
               {codeSnippets[selectedLanguage]}
             </SyntaxHighlighter>
           </div>
         </div>
+
+        <p className="text-[12px] text-[#6b7280] text-center mt-6">
+          Powered by{" "}
+          <a
+            href="https://zuplo.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#FF00BD] font-semibold hover:underline"
+          >
+            Zuplo
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,30 +1,34 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 focus-visible:ring-4 focus-visible:outline-1 aria-invalid:focus-visible:ring-0",
+  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-lg font-semibold transition-[background-color,border-color,color] disabled:pointer-events-none disabled:opacity-40 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--accent-ghost)] focus-visible:border-[var(--accent)]",
   {
     variants: {
       variant: {
+        // Primary — pink CTA
         default:
-          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90",
+          "bg-[#FF00BD] text-white hover:bg-[#e600aa] shadow-[0_1px_6px_rgba(255,0,189,0.35)]",
+        // Dark — black workhorse
+        dark: "bg-[#111827] text-white hover:bg-[#1f2937]",
+        // Danger
+        destructive: "bg-[#e11d48] text-white hover:bg-[#be123c]",
+        // Outlined
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-white text-[#374151] border border-[#e5e7eb] hover:bg-[#f3f4f6]",
+        // Ghost
+        ghost: "bg-transparent text-[#374151] hover:bg-[#f3f4f6]",
+        // Link
+        link: "text-[#FF00BD] underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: "h-9 px-4 text-[13px]",
+        sm: "h-8 px-3 text-[13px]",
+        lg: "h-10 px-5 text-[13px]",
+        icon: "h-9 w-9 p-0",
       },
     },
     defaultVariants: {
@@ -32,7 +36,7 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 function Button({
   className,
@@ -42,9 +46,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -52,7 +56,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/custom-select.tsx
+++ b/src/components/ui/custom-select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, CaretDown } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 
@@ -19,14 +19,14 @@ const CustomSelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-12 w-full items-center justify-between rounded-lg border-0 bg-[#2d3748] px-4 py-2 text-base text-white shadow-sm ring-0 ring-offset-0 focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
+      "flex h-9 w-full items-center justify-between rounded-lg border border-[#e5e7eb] bg-white px-3 text-[13px] font-medium text-[#111827] transition-[border-color,box-shadow] focus:outline-none focus:border-[#FF00BD] focus:ring-[3px] focus:ring-[var(--accent-ghost)] disabled:cursor-not-allowed disabled:opacity-50",
       className
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-5 w-5 opacity-70" />
+      <CaretDown size={14} weight="regular" className="text-[#6b7280]" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -40,7 +40,7 @@ const CustomSelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 min-w-[8rem] overflow-hidden rounded-lg border-0 bg-[#2d3748] text-white shadow-md animate-in fade-in-80",
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-lg border border-[#e5e7eb] bg-white text-[#111827] shadow-[0_6px_24px_rgba(0,0,0,0.10)] animate-in fade-in-80",
         position === "popper" && "translate-y-1",
         className
       )}
@@ -49,7 +49,7 @@ const CustomSelectContent = React.forwardRef<
     >
       <SelectPrimitive.Viewport
         className={cn(
-          "p-1",
+          "p-1.5",
           position === "popper" &&
             "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}
@@ -68,7 +68,7 @@ const CustomSelectLabel = React.forwardRef<
   <SelectPrimitive.Label
     ref={ref}
     className={cn(
-      "py-1.5 pl-8 pr-2 text-sm font-semibold text-white",
+      "px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-[#9ca3af]",
       className
     )}
     {...props}
@@ -83,14 +83,14 @@ const CustomSelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full select-none items-center py-2 pl-10 pr-4 text-base text-white outline-none transition-colors data-[highlighted]:bg-[#374151] data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50 cursor-pointer",
+      "relative flex w-full select-none items-center gap-2 rounded-md py-2 pl-8 pr-3 text-[13px] text-[#374151] outline-none transition-colors data-[highlighted]:bg-[#f3f4f6] data-[highlighted]:text-[#111827] data-[disabled]:pointer-events-none data-[disabled]:opacity-50 cursor-pointer",
       className
     )}
     {...props}
   >
-    <span className="absolute left-3 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2.5 flex h-4 w-4 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-5 w-5 text-white" />
+        <Check size={14} weight="regular" className="text-[#FF00BD]" />
       </SelectPrimitive.ItemIndicator>
     </span>
 
@@ -105,7 +105,7 @@ const CustomSelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-[#4a5568]", className)}
+    className={cn("-mx-1 my-1 h-px bg-[#e5e7eb]", className)}
     {...props}
   />
 ));

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,12 @@
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+@import url("https://fonts.googleapis.com/css2?family=Readex+Pro:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400;500;600&display=swap");
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+:root {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #111827;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -13,56 +14,29 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #ffffff;
+  color: #111827;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+h1,
+h2,
+h3,
+h4 {
+  font-family: "Readex Pro", sans-serif;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  margin: 0;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+code,
+pre,
+kbd,
+samp {
+  font-family: "Fira Code", "SF Mono", ui-monospace, "Cascadia Code",
+    "JetBrains Mono", monospace;
+  font-weight: 400;
 }

--- a/src/zuplo-banner.js
+++ b/src/zuplo-banner.js
@@ -44,7 +44,7 @@ class ZuploBanner extends HTMLElement {
 
     const zuploLogoContainer = document.createElement("a");
     zuploLogoContainer.setAttribute("class", "zuplo-logo");
-    zuploLogoContainer.setAttribute("href", "https://zuplo.com");
+    zuploLogoContainer.setAttribute("href", "https://zuplo.com?utm_source=uuid-new&utm_campaign=opensource&utm_medium=web");
     zuploLogoContainer.setAttribute("target", "_blank");
     zuploLogoContainer.setAttribute("rel", "noopener noreferrer");
     zuploLogoContainer.setAttribute("aria-label", "Zuplo");

--- a/src/zuplo-banner.js
+++ b/src/zuplo-banner.js
@@ -2,22 +2,20 @@ class ZuploBanner extends HTMLElement {
   constructor() {
     super();
 
-    // Attach a shadow root
     const shadow = this.attachShadow({ mode: "open" });
 
-    // JSON data for the tools
     const toolsData = {
       zudoku: {
         name: "Zudoku",
         logo: "https://cdn.zuplo.com/uploads/zudoku-logo-only.svg",
         description: "API documentation should be free.",
-        url: "https://zudoku.dev?utm_source=mockbin&utm_medium=web&utm_campaign=header&ref=mockbin",
+        url: "https://zudoku.dev?utm_source=uuidnew&utm_medium=web&utm_campaign=header&ref=uuidnew",
       },
       ratemyopenapi: {
         name: "Rate My OpenAPI",
         logo: "https://cdn.zuplo.com/uploads/rmoa-logo-only.svg",
         description: "Get feedback and a rating on your OpenAPI spec",
-        url: "https://ratemyopenapi.com?utm_source=mockbin&utm_medium=web&utm_campaign=header&ref=mockbin",
+        url: "https://ratemyopenapi.com?utm_source=uuidnew&utm_medium=web&utm_campaign=header&ref=uuidnew",
       },
       mockbin: {
         name: "Mockbin",
@@ -33,73 +31,61 @@ class ZuploBanner extends HTMLElement {
       },
     };
 
-    // Create wrapper
     const wrapper = document.createElement("div");
     wrapper.setAttribute("class", "zuplo-banner");
 
-    // Left side: Text and logo
+    // Left: "Open source by" + Zuplo wordmark
     const leftDiv = document.createElement("div");
     leftDiv.setAttribute("class", "left");
 
     const openSourceText = document.createElement("span");
-    openSourceText.textContent = "Open source by ";
+    openSourceText.setAttribute("class", "tagline");
+    openSourceText.textContent = "Open source by";
 
-    // Zuplo Logo using the provided SVG
-    const zuploLogoContainer = document.createElement("div");
+    const zuploLogoContainer = document.createElement("a");
     zuploLogoContainer.setAttribute("class", "zuplo-logo");
-    zuploLogoContainer.innerHTML = `
-      <!-- Zuplo SVG Logo -->
-      ${this.getZuploLogoSVG()}
-    `;
+    zuploLogoContainer.setAttribute("href", "https://zuplo.com");
+    zuploLogoContainer.setAttribute("target", "_blank");
+    zuploLogoContainer.setAttribute("rel", "noopener noreferrer");
+    zuploLogoContainer.setAttribute("aria-label", "Zuplo");
+    zuploLogoContainer.innerHTML = this.getZuploLogoSVG();
 
     leftDiv.appendChild(openSourceText);
     leftDiv.appendChild(zuploLogoContainer);
 
-    // Right side: Button with grip icon and "View Tools" text
+    // Right: "View Tools" outlined button
     const rightDiv = document.createElement("div");
     rightDiv.setAttribute("class", "right");
 
     const menuButton = document.createElement("button");
     menuButton.setAttribute("class", "menu-button");
+    menuButton.setAttribute("type", "button");
+    menuButton.setAttribute("aria-haspopup", "true");
+    menuButton.setAttribute("aria-expanded", "false");
 
-    // Grip icon SVG
+    // Phosphor DotsNine icon (3x3 grid)
     const gripIconSVG = `
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-           stroke="currentColor" fill="none" stroke-width="2"
-           stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="2" cy="2" r="1"/>
-        <circle cx="8" cy="2" r="1"/>
-        <circle cx="14" cy="2" r="1"/>
-        <circle cx="2" cy="8" r="1"/>
-        <circle cx="8" cy="8" r="1"/>
-        <circle cx="14" cy="8" r="1"/>
-        <circle cx="2" cy="14" r="1"/>
-        <circle cx="8" cy="14" r="1"/>
-        <circle cx="14" cy="14" r="1"/>
+           viewBox="0 0 256 256" fill="currentColor" fill-rule="evenodd"
+           aria-hidden="true">
+        <path d="M76,64A12,12,0,1,1,64,52,12,12,0,0,1,76,64Zm52-12a12,12,0,1,0,12,12A12,12,0,0,0,128,52Zm64,24a12,12,0,1,0-12-12A12,12,0,0,0,192,76ZM64,116a12,12,0,1,0,12,12A12,12,0,0,0,64,116Zm64,0a12,12,0,1,0,12,12A12,12,0,0,0,128,116Zm64,0a12,12,0,1,0,12,12A12,12,0,0,0,192,116ZM64,180a12,12,0,1,0,12,12A12,12,0,0,0,64,180Zm64,0a12,12,0,1,0,12,12A12,12,0,0,0,128,180Zm64,0a12,12,0,1,0,12,12A12,12,0,0,0,192,180Z"></path>
       </svg>
     `;
 
-    // Add "View Tools" text and icon to the button
-    const buttonContent = document.createElement("span");
-    buttonContent.setAttribute("class", "button-content");
-    buttonContent.innerHTML = `${gripIconSVG}<span class="button-text">View Tools</span>`;
-
-    menuButton.appendChild(buttonContent);
+    menuButton.innerHTML = `${gripIconSVG}<span class="button-text">View Tools</span>`;
 
     rightDiv.appendChild(menuButton);
 
-    // Append left and right divs to wrapper
     wrapper.appendChild(leftDiv);
     wrapper.appendChild(rightDiv);
 
-    // Append wrapper to shadow root
     shadow.appendChild(wrapper);
 
-    // Create the menu (initially hidden)
+    // Dropdown menu card
     const menu = document.createElement("div");
     menu.setAttribute("class", "menu");
+    menu.setAttribute("role", "menu");
 
-    // Create menu items based on toolsData
     for (const key in toolsData) {
       const tool = toolsData[key];
 
@@ -107,10 +93,16 @@ class ZuploBanner extends HTMLElement {
       menuItem.setAttribute("href", tool.url);
       menuItem.setAttribute("class", "menu-item");
       menuItem.setAttribute("target", "_blank");
+      menuItem.setAttribute("rel", "noopener noreferrer");
+      menuItem.setAttribute("role", "menuitem");
 
+      const logoWrap = document.createElement("div");
+      logoWrap.setAttribute("class", "menu-item-logo");
       const logo = document.createElement("img");
       logo.setAttribute("src", tool.logo);
-      logo.setAttribute("alt", tool.name);
+      logo.setAttribute("alt", "");
+      logo.setAttribute("aria-hidden", "true");
+      logoWrap.appendChild(logo);
 
       const textContainer = document.createElement("div");
       textContainer.setAttribute("class", "text-container");
@@ -125,219 +117,262 @@ class ZuploBanner extends HTMLElement {
 
       textContainer.appendChild(name);
       textContainer.appendChild(description);
-      menuItem.appendChild(logo);
+      menuItem.appendChild(logoWrap);
       menuItem.appendChild(textContainer);
 
       menu.appendChild(menuItem);
     }
 
-    // Add the footer to the menu
-    const menuFooter = document.createElement("div");
-    menuFooter.setAttribute("class", "menu-footer");
-    menuFooter.textContent = "Created with ❤️ by Zuplo";
-
-    menu.appendChild(menuFooter);
-
-    // Append menu to the rightDiv instead of shadow root
     rightDiv.appendChild(menu);
 
-    // Handle button click to toggle menu visibility
     menuButton.addEventListener("click", (event) => {
       event.stopPropagation();
-      menu.classList.toggle("visible");
+      const isOpen = menu.classList.toggle("visible");
+      menuButton.setAttribute("aria-expanded", isOpen ? "true" : "false");
     });
 
-    // Close menu when clicking outside
     document.addEventListener("click", (event) => {
       if (!this.contains(event.target)) {
         menu.classList.remove("visible");
+        menuButton.setAttribute("aria-expanded", "false");
       }
     });
 
-    // Styles
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        menu.classList.remove("visible");
+        menuButton.setAttribute("aria-expanded", "false");
+      }
+    });
+
     const style = document.createElement("style");
     style.textContent = `
-      /* Set font family to Helvetica throughout */
+      :host {
+        --fg: #111827;
+        --fg-secondary: #374151;
+        --fg-muted: #6b7280;
+        --bg: #ffffff;
+        --bg-muted: #f3f4f6;
+        --border: #e5e7eb;
+        --accent: #FF00BD;
+        --shadow-lg: 0 6px 24px rgba(0,0,0,0.10);
+        --shadow-sm: 0 1px 3px rgba(0,0,0,0.04);
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+
       * {
-        font-family: 'Helvetica', sans-serif;
         box-sizing: border-box;
       }
+
       .zuplo-banner {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        background-color: white;
-        color: black;
+        background-color: var(--bg);
+        color: var(--fg);
         padding: 10px 20px;
         width: 100%;
-        flex-wrap: nowrap; /* Prevent wrapping */
+        flex-wrap: nowrap;
+        border-bottom: 1px solid var(--border);
       }
+
       .left {
         display: flex;
         align-items: center;
+        gap: 10px;
       }
-      .left .zuplo-logo {
-        height: 20px;
-        margin-left: 10px;
-        display: flex;
-        align-items: center; /* Center vertically */
-        position: relative;
-        top: 1px; /* Move down slightly */
+
+      .tagline {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--fg-muted);
+        line-height: 1;
       }
-      .left .zuplo-logo svg {
+
+      .zuplo-logo {
+        display: inline-flex;
+        align-items: center;
+        height: 24px;
+        text-decoration: none;
+        color: var(--fg);
+      }
+
+      .zuplo-logo svg {
         height: 100%;
         width: auto;
+        display: block;
       }
+
       .right {
         position: relative;
         display: flex;
         align-items: center;
       }
+
       .menu-button {
-        display: flex;
+        display: inline-flex;
         align-items: center;
-        background-color: #ff00bd;
-        color: white;
-        border: none;
-        padding: 10px 16px;
-        border-radius: 5px;
+        gap: 8px;
+        background-color: var(--bg);
+        color: var(--fg-secondary);
+        border: 1px solid var(--border);
+        height: 36px;
+        padding: 0 14px;
+        border-radius: 8px;
         cursor: pointer;
-        font-size: 16px;
+        font-family: inherit;
+        font-size: 13px;
+        font-weight: 600;
         line-height: 1;
-        white-space: nowrap; /* Prevent text wrapping */
+        white-space: nowrap;
+        transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
       }
-      .menu-button .button-content {
-        display: flex;
-        align-items: center;
-        justify-content: center;
+
+      .menu-button:hover {
+        background-color: var(--bg-muted);
+        color: var(--fg);
       }
+
+      .menu-button:focus-visible {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px rgba(255, 0, 189, 0.08);
+      }
+
       .menu-button svg {
-        width: 20px;
-        height: 20px;
-        margin-right: 8px;
+        width: 16px;
+        height: 16px;
+        flex-shrink: 0;
       }
-      .menu-button .button-text {
-        display: inline-block;
-      }
+
       .menu {
         display: none;
         position: absolute;
         right: 0;
-        top: calc(100% + 5px); /* Place below the button with 5px margin */
-        background-color: white;
-        color: black;
-        box-shadow: 0 4px 10px rgba(0,0,0,0.1); /* Add shadow */
-        z-index: 9999; /* High z-index */
-        width: auto; /* Adjust width */
-        min-width: 200px; /* Optional: set a minimum width */
-        padding: 10px;
+        top: calc(100% + 8px);
+        background-color: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        box-shadow: var(--shadow-lg);
+        z-index: 9999;
+        min-width: 340px;
+        padding: 8px;
+        animation: fadeSlideIn 0.18s ease-out;
       }
+
       .menu.visible {
         display: block;
       }
+
+      @keyframes fadeSlideIn {
+        from {
+          opacity: 0;
+          transform: translateY(-4px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
       .menu-item {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
+        gap: 14px;
         text-decoration: none;
-        color: black;
-        padding: 10px 0;
-        border-bottom: 1px solid #eee;
+        color: var(--fg);
+        padding: 12px;
+        border-radius: 8px;
+        transition: background-color 0.15s ease;
       }
-      .menu-item:last-child {
-        border-bottom: none;
+
+      .menu-item:hover {
+        background-color: var(--bg-muted);
       }
-      .menu-item img {
-        width: 40px;
-        height: 40px;
-        margin-right: 10px;
+
+      .menu-item-logo {
+        width: 36px;
+        height: 36px;
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
+
+      .menu-item-logo img {
+        width: 36px;
+        height: 36px;
+        object-fit: contain;
+        display: block;
+      }
+
       .text-container {
         display: flex;
         flex-direction: column;
+        gap: 2px;
+        min-width: 0;
       }
+
       .tool-name {
-        font-weight: bold;
-        white-space: nowrap; /* Prevent wrapping */
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--fg);
+        line-height: 1.3;
       }
+
       .tool-description {
-        font-size: 12px;
-        color: #666;
+        font-size: 13px;
+        font-weight: 400;
+        color: var(--fg-muted);
+        line-height: 1.4;
       }
-      .menu-footer {
-        text-align: center;
-        margin-top: 10px;
-        font-size: 12px;
-        color: #666;
-      }
+
       /* Responsive */
       @media (max-width: 600px) {
         .zuplo-banner {
-          flex-direction: column-reverse; /* Stack left content below right */
-          align-items: center; /* Center horizontally */
+          padding: 10px 14px;
         }
-        .left {
-          margin-top: 10px;
-        }
-        .right {
-          margin-top: 0;
-          width: auto;
-          justify-content: center;
+        .tagline {
+          display: none;
         }
         .menu {
-          right: 0;
-          width: auto; /* Ensure menu is as wide as needed */
+          min-width: 280px;
         }
       }
     `;
 
-    // Handle mode attribute
     const mode = this.getAttribute("mode") || "light";
 
     if (mode === "dark") {
       style.textContent += `
-        .zuplo-banner {
-          background-color: black;
-          color: white;
-        }
-        .menu {
-          background-color: black;
-          color: white;
-        }
-        .menu-item {
-          color: white;
-        }
-        .menu-footer {
-          color: #ccc;
-        }
-        .menu-button {
-          background-color: #ff00bd;
-          color: white;
-        }
-        /* Invert Zuplo logo for dark mode */
-        .left .zuplo-logo svg path {
-          fill: white;
-        }
-      `;
-    } else {
-      /* Set Zuplo logo color for light mode */
-      style.textContent += `
-        .left .zuplo-logo svg path {
-          fill: black;
+        :host {
+          --fg: #f8fafc;
+          --fg-secondary: #e2e8f0;
+          --fg-muted: #94a3b8;
+          --bg: #111827;
+          --bg-muted: #1f2937;
+          --border: #1f2937;
         }
       `;
     }
 
-    // Append styles to shadow root
     shadow.appendChild(style);
   }
 
-  // Method to return the Zuplo SVG logo
   getZuploLogoSVG() {
     return `
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true" viewBox="0 0 147 33" alt="Zuplo logo" class="w-auto h-8"><path fill="#FFF" d="M27.142 19.978H16.62L27.83 8.746a.758.758 0 0 0-.534-1.293H9.488V0h19.534a7.57 7.57 0 0 1 4.065 1.125 7.6 7.6 0 0 1 2.836 3.126 7.4 7.4 0 0 1-1.461 8.398l-7.32 7.328z"></path><path fill="#FFF" d="M9.489 11.042h10.524l-11.19 11.21a.772.772 0 0 0 .543 1.316h17.759v7.452H7.61a7.57 7.57 0 0 1-4.065-1.125A7.6 7.6 0 0 1 .71 26.768a7.4 7.4 0 0 1 1.462-8.397zm73.297 5.728c0 2.657-1.034 4.283-3.46 4.244-2.227-.04-3.38-1.666-3.38-4.283V6.696h-5.488v10.43c0 5.038 3.142 8.607 8.868 8.647 5.25.04 8.948-3.807 8.948-8.606V6.697h-5.488zm53.306-10.512c-5.925 0-10.098 4.204-10.098 9.757 0 5.552 4.175 9.756 10.098 9.756s10.099-4.204 10.099-9.756-4.173-9.757-10.099-9.757m0 14.794c-2.744 0-4.69-2.063-4.69-5.037 0-2.975 1.948-5.038 4.69-5.038s4.691 2.063 4.691 5.038-1.947 5.037-4.691 5.037M101.966 6.258c-5.926 0-10.099 4.204-10.099 9.757 0 .073.009.144.01.22h-.01v15.772h5.408V24.75a10.9 10.9 0 0 0 4.691 1.02c5.926 0 10.099-4.204 10.099-9.756s-4.173-9.756-10.099-9.756m0 14.794c-2.744 0-4.69-2.063-4.69-5.037 0-2.975 1.948-5.038 4.69-5.038s4.691 2.063 4.691 5.038-1.947 5.037-4.691 5.037M49.868 11.41h10.814l-10.814 8.452v5.473h17.514v-4.716h-10.84l10.84-8.473V6.694H49.868zm74.501 13.925h-1.831a7.46 7.46 0 0 1-5.262-2.177 7.42 7.42 0 0 1-2.183-5.248V.005h5.518V17.91a1.927 1.927 0 0 0 1.927 1.921h1.831z"></path></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 39" fill="none" aria-hidden="true" class="zuplo-wordmark">
+        <path d="M26.5769 23.3789H16.2723L27.2516 12.4273C27.3551 12.324 27.4256 12.1924 27.4541 12.0492C27.4826 11.9059 27.4681 11.7575 27.412 11.6225C27.356 11.4876 27.2611 11.3723 27.1394 11.2911C27.0177 11.2099 26.8746 11.1666 26.7281 11.1666H9.29082V3.90057H28.4171C29.8212 3.88352 31.2013 4.26394 32.3974 4.99771C33.5934 5.73149 34.5564 6.78853 35.1745 8.04617C35.8127 9.39123 36.0178 10.9004 35.7616 12.3664C35.5055 13.8324 34.8006 15.1833 33.7438 16.2337L26.5769 23.3789Z" fill="currentColor"/>
+        <path d="M9.29089 14.6662H19.596L8.63877 25.5957C8.53351 25.7009 8.46186 25.8348 8.43284 25.9805C8.40382 26.1262 8.41878 26.2772 8.47577 26.4145C8.53275 26.5518 8.62915 26.6691 8.75295 26.7517C8.87675 26.8343 9.02237 26.8785 9.17131 26.8786H26.5595V34.1446H7.45164C6.04759 34.1615 4.66759 33.781 3.47154 33.0473C2.2755 32.3135 1.31246 31.2565 0.694269 29.9989C0.0561353 28.6538 -0.148879 27.1446 0.107392 25.6786C0.363663 24.2126 1.06871 22.8617 2.12559 21.8114L9.29089 14.6662Z" fill="currentColor"/>
+        <path d="M81.0615 20.2506C81.0615 22.8413 80.0489 24.427 77.6735 24.3883C75.4927 24.3497 74.3634 22.764 74.3634 20.2125V10.4287H68.9901V20.5983C68.9901 25.5097 72.0664 28.9901 77.6735 29.0288C82.8139 29.0674 86.4353 25.3166 86.4353 20.6374V10.4287H81.0615V20.2506Z" fill="currentColor"/>
+        <path d="M133.257 10.0017C127.455 10.0017 123.369 14.1007 123.369 19.5145C123.369 24.9282 127.458 29.0272 133.257 29.0272C139.057 29.0272 143.145 24.9282 143.145 19.5145C143.145 14.1007 139.059 10.0017 133.257 10.0017ZM133.257 24.4254C130.57 24.4254 128.664 22.4148 128.664 19.5145C128.664 16.6142 130.572 14.603 133.257 14.603C135.942 14.603 137.85 16.6142 137.85 19.5145C137.85 22.4148 135.944 24.4254 133.257 24.4254Z" fill="currentColor" fill-rule="evenodd"/>
+        <path d="M99.8417 10.0016C94.0394 10.0016 89.9533 14.1007 89.9533 19.5144C89.9533 19.5863 89.9618 19.6555 89.9629 19.729H89.9533V35.1068H95.2487V28.0313C96.6861 28.6982 98.2552 29.038 99.8417 29.0261C105.644 29.0261 109.73 24.927 109.73 19.5133C109.73 14.0996 105.644 10.0016 99.8417 10.0016ZM99.8417 24.4253C97.1545 24.4253 95.2487 22.4147 95.2487 19.5144C95.2487 16.6141 97.1567 14.6029 99.8417 14.6029C102.527 14.6029 104.435 16.6141 104.435 19.5144C104.435 22.4147 102.529 24.4253 99.8417 24.4253Z" fill="currentColor" fill-rule="evenodd"/>
+        <path d="M48.8292 15.0252H59.4179L48.8292 23.2652V28.6017H65.9783V24.0036H55.3642L65.9783 15.7427V10.4271H48.8292V15.0252Z" fill="currentColor"/>
+        <path d="M121.778 28.6016H119.985C118.052 28.5995 116.199 27.8361 114.832 26.479C113.466 25.1218 112.697 23.2817 112.695 21.3624V3.90527H118.098V21.3624C118.1 21.8589 118.299 22.3345 118.652 22.6856C119.006 23.0366 119.485 23.2344 119.985 23.2357H121.778V28.6016Z" fill="currentColor"/>
+      </svg>
     `;
   }
 }
 
-// Define the custom element
 customElements.define("zuplo-banner", ZuploBanner);


### PR DESCRIPTION
## Summary
- Rebuild design tokens to match Zuplo design system: Readex Pro headings, Inter body, Fira Code mono, accent `#FF00BD`, neutral palette, dark `#1e1e2e` code surface.
- Swap `lucide-react` for `@phosphor-icons/react` (Regular weight, evenodd fill-rule).
- Rework button variants (Primary/Dark/Outline/Ghost/Destructive) with cursor-pointer baseline; redesign UUID card to value-first layout with copy-success emerald state.
- Redesign `zuplo-banner` web component: real Zuplo wordmark, outlined "View Tools" button, polished dropdown card, Inter font, Esc-to-close, dark-mode support.

## Test plan
- [ ] `npm run build` passes
- [ ] Visual check `npm run dev` — light theme, pink primary CTA, dark code block, banner matches brand
- [ ] Generate + copy UUID works, copy state flips to green check
- [ ] Language switcher updates code snippet
- [ ] "View Tools" dropdown opens, closes on outside click + Esc

🤖 Generated with [Claude Code](https://claude.com/claude-code)